### PR TITLE
Fix CSS and Mixed Content errors

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 # Dependencies
-markdown:         redcarpet
+markdown:         kramdown
 pygments:         true
 
 # Permalinks

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,5 @@
 # Dependencies
 markdown:         kramdown
-pygments:         true
 
 # Permalinks
 permalink:        pretty

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -20,7 +20,7 @@
 
   <!-- Icons -->
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/public/apple-touch-icon-144-precomposed.png">
-  <link rel="shortcut icon" href="/public/favicon.ico">
+  <link rel="shortcut icon" href="public/favicon.ico">
 
   <!-- RSS -->
   <link rel="alternate" type="application/rss+xml" title="RSS" href="/atom.xml">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,9 +13,9 @@
   </title>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/lanyon/css/poole.css">
-  <link rel="stylesheet" href="/lanyon/css/syntax.css">
-  <link rel="stylesheet" href="/lanyon/css/lanyon.css">
+  <link rel="stylesheet" href="public/css/poole.css">
+  <link rel="stylesheet" href="public/css/syntax.css">
+  <link rel="stylesheet" href="public/css/lanyon.css">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700|PT+Sans:400">
 
   <!-- Icons -->

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,5 +1,4 @@
 <head>
-  <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
 
   <!-- Enable responsiveness on mobile devices-->
@@ -17,7 +16,7 @@
   <link rel="stylesheet" href="/lanyon/css/poole.css">
   <link rel="stylesheet" href="/lanyon/css/syntax.css">
   <link rel="stylesheet" href="/lanyon/css/lanyon.css">
-  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700|PT+Sans:400">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700|PT+Sans:400">
 
   <!-- Icons -->
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/public/apple-touch-icon-144-precomposed.png">


### PR DESCRIPTION
Hi @indre-waldemar 👋 

These are the changes that I was referring to in the email I sent you. It will update the following:

1. Your mixed content errors will be resolved by updating the `http://` links to `https://`
2. It will update the relative links to your CSS files
3. (bonus `#1`) I noticed that the favicon link was also pointed to the wrong place, so I updated that as well
4. (bonus `#2`) The `_config.yml` file was configured to use a depreciated markdown processor. I updated that as well so you could avoid build warnings.

Feel free to merge this Pull Request to resolve the issue, or just look over the changes I made for your own understanding.